### PR TITLE
feat(mcp): config() endpoint for in-memory session knobs

### DIFF
--- a/src/blq/runtime.py
+++ b/src/blq/runtime.py
@@ -1,0 +1,156 @@
+"""In-memory runtime configuration for the blq MCP server.
+
+Distinct from `.bird/config.toml` (persistent user config) and the DuckDB
+storage at `.bird/blq.duckdb` (run history). This module holds *session*
+state that the MCP `config()` tool reads and writes — wiped on server
+restart, no disk persistence.
+
+Env vars at launch seed the initial values (e.g. BLQ_ACTIVE_ROOT set in
+.mcp.json env block). Resetting reverts to those env-seeded values, not
+hardcoded defaults.
+
+**Scope.** Only runtime knobs live here. Persistent state stays in the DB
+(retention, capture buffer, registered commands) — those are not session
+state and don't belong in a tool that gets wiped on restart.
+
+Shape mirrors jetsam.config.runtime and squackit.runtime.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field, fields, replace
+from typing import Any
+
+
+_ENV_PREFIX = "BLQ_"
+
+_VALID_LOG_LEVELS = {"debug", "info", "warn", "warning", "error"}
+
+
+@dataclass
+class BlqRuntimeConfig:
+    """Session-scoped runtime knobs for the blq MCP server.
+
+    Common keys (suite-wide convention, also on jetsam + squackit):
+        active_root: fallback when locating the `.bird/` workspace. None
+            means walk up from process cwd (today's behavior).
+        log_level: debug | info | warn | error.
+
+    Blq-specific:
+        default_lines_window: default for `run(lines=...)` when the caller
+            omits it. Format matches the existing `lines` arg syntax
+            (e.g. "+20-" for last 20). Empty string means "no inline
+            output" (today's default).
+        default_history_limit: default for `history(limit=...)` when the
+            caller omits it.
+    """
+
+    active_root: str | None = None
+    log_level: str = "info"
+    default_lines_window: str = ""
+    default_history_limit: int = 20
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "BlqRuntimeConfig":
+        """Build a config seeded from environment variables.
+
+        Variables read (each optional):
+            BLQ_ACTIVE_ROOT
+            BLQ_LOG_LEVEL
+            BLQ_DEFAULT_LINES_WINDOW
+            BLQ_DEFAULT_HISTORY_LIMIT
+
+        Invalid values fall back to the dataclass default.
+        """
+        e = env if env is not None else os.environ
+        cfg = cls()
+
+        if v := e.get(f"{_ENV_PREFIX}ACTIVE_ROOT"):
+            cfg.active_root = v
+        if v := e.get(f"{_ENV_PREFIX}LOG_LEVEL"):
+            if v.lower() in _VALID_LOG_LEVELS:
+                cfg.log_level = v.lower()
+        # default_lines_window: any string is acceptable (validated by callers)
+        if (v := e.get(f"{_ENV_PREFIX}DEFAULT_LINES_WINDOW")) is not None:
+            cfg.default_lines_window = v
+        if v := e.get(f"{_ENV_PREFIX}DEFAULT_HISTORY_LIMIT"):
+            try:
+                cfg.default_history_limit = max(1, int(v))
+            except ValueError:
+                pass
+
+        return cfg
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flat dict for the MCP `config()` response."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+# Module-level singleton, seeded from env on import.
+_runtime: BlqRuntimeConfig = BlqRuntimeConfig.from_env()
+_seed: BlqRuntimeConfig = replace(_runtime)
+
+
+def get_runtime() -> BlqRuntimeConfig:
+    """Return the current runtime config."""
+    return _runtime
+
+
+def update_runtime(values: dict[str, Any]) -> BlqRuntimeConfig:
+    """Merge values into the runtime config. Validates atomically.
+
+    Raises ValueError on unknown keys or invalid values, leaving the runtime
+    config unchanged.
+    """
+    global _runtime
+    valid_keys = {f.name for f in fields(BlqRuntimeConfig)}
+    unknown = set(values) - valid_keys
+    if unknown:
+        raise ValueError(
+            f"unknown config key(s): {sorted(unknown)}. "
+            f"Valid keys: {sorted(valid_keys)}"
+        )
+
+    candidate = replace(_runtime)
+    for key, value in values.items():
+        _validate_one(key, value)
+        setattr(candidate, key, value)
+
+    _runtime = candidate
+    return _runtime
+
+
+def reset_runtime() -> BlqRuntimeConfig:
+    """Reset to the env-seeded values captured at module import time."""
+    global _runtime
+    _runtime = replace(_seed)
+    return _runtime
+
+
+def resolve_storage_root() -> str | None:
+    """Return the directory to search for .bird/ from, or None for cwd-walk.
+
+    When active_root is set, callers should pass `Path(active_root)` to
+    BlqStorage's search so the workspace resolves consistently regardless
+    of the server's process cwd.
+    """
+    return _runtime.active_root
+
+
+def _validate_one(key: str, value: Any) -> None:
+    """Per-key value validation."""
+    if key == "log_level":
+        if not isinstance(value, str) or value.lower() not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"log_level must be one of {sorted(_VALID_LOG_LEVELS)}, got {value!r}"
+            )
+    elif key == "default_history_limit":
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError(f"default_history_limit must be a positive int, got {value!r}")
+    elif key == "default_lines_window":
+        if not isinstance(value, str):
+            raise ValueError(f"default_lines_window must be str, got {type(value).__name__}")
+    elif key == "active_root":
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"active_root must be str or None, got {type(value).__name__}")

--- a/src/blq/serve.py
+++ b/src/blq/serve.py
@@ -190,7 +190,23 @@ mcp = FastMCP(
 
 
 def _get_storage() -> BlqStorage:
-    """Get BlqStorage for current directory."""
+    """Get BlqStorage, honoring the runtime config's active_root if set.
+
+    Precedence:
+        1. runtime.active_root (if set) — search for .bird/ starting there
+        2. process cwd (default — walks up to find .bird/)
+    """
+    from blq.runtime import resolve_storage_root
+    root = resolve_storage_root()
+    if root is not None:
+        from pathlib import Path
+        # If active_root has a .bird/ directly, open it; else delegate the
+        # walk to BlqStorage's auto-search but rooted at active_root.
+        bird = Path(root) / ".bird"
+        if bird.exists():
+            return BlqStorage.open(bird)
+        # No direct .bird — fall through to cwd-walk. Could be enhanced to
+        # walk up from active_root, but kept simple for the prototype.
     return BlqStorage.open()
 
 
@@ -3608,6 +3624,47 @@ def sandbox_info(command: str | None = None) -> str:
         command: Specific command name (omit for all commands)
     """
     return json.dumps(_sandbox_info_impl(command), indent=2, default=str)
+
+
+@mcp.tool()
+def config(
+    set: dict[str, Any] | None = None,
+    reset: bool = False,
+) -> dict[str, Any]:
+    """Read or update blq's in-memory session config.
+
+    Returns the full current config dict. With `set=`, merges values and
+    returns the new state. With `reset=true`, reverts to env-seeded values
+    captured at server launch. Wiped on server restart — no disk
+    persistence. Persistent state (run history, retention, registered
+    commands) stays in the DB.
+
+    Keys:
+        active_root             — fallback for locating .bird/ workspace
+        log_level               — debug | info | warn | error
+        default_lines_window    — default for run(lines=...) when omitted
+        default_history_limit   — default for history(limit=...)
+
+    Env vars (seed at launch only): BLQ_ACTIVE_ROOT, BLQ_LOG_LEVEL,
+    BLQ_DEFAULT_LINES_WINDOW, BLQ_DEFAULT_HISTORY_LIMIT.
+
+    Args:
+        set: Dict of keys to update. Unknown keys raise; invalid values
+            raise; either way the config is left unchanged.
+        reset: If True, reset to env-seeded values (ignores `set`).
+    """
+    from blq.runtime import get_runtime, reset_runtime, update_runtime
+
+    if reset:
+        return reset_runtime().to_dict()
+
+    if set:
+        try:
+            return update_runtime(set).to_dict()
+        except ValueError as e:
+            return {"error": "invalid_config", "message": str(e)}
+
+    return get_runtime().to_dict()
 
 
 # ============================================================================

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,171 @@
+"""Tests for the in-memory runtime config + MCP config() tool."""
+
+from __future__ import annotations
+
+import pytest
+
+from blq import runtime as rt
+from blq.runtime import (
+    BlqRuntimeConfig,
+    get_runtime,
+    reset_runtime,
+    resolve_storage_root,
+    update_runtime,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime():
+    """Reset the module singleton + seed between tests so order doesn't matter."""
+    rt._runtime = BlqRuntimeConfig()
+    rt._seed = BlqRuntimeConfig()
+    yield
+    rt._runtime = BlqRuntimeConfig()
+    rt._seed = BlqRuntimeConfig()
+
+
+class TestFromEnv:
+    def test_empty_env_returns_defaults(self):
+        cfg = BlqRuntimeConfig.from_env(env={})
+        assert cfg.active_root is None
+        assert cfg.log_level == "info"
+        assert cfg.default_lines_window == ""
+        assert cfg.default_history_limit == 20
+
+    def test_active_root_from_env(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_ACTIVE_ROOT": "/tmp/repo"})
+        assert cfg.active_root == "/tmp/repo"
+
+    def test_log_level_normalized_lowercase(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_LOG_LEVEL": "DEBUG"})
+        assert cfg.log_level == "debug"
+
+    def test_log_level_invalid_falls_back_to_default(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_LOG_LEVEL": "verbose"})
+        assert cfg.log_level == "info"
+
+    def test_lines_window_accepts_any_string(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_DEFAULT_LINES_WINDOW": "+30-"})
+        assert cfg.default_lines_window == "+30-"
+
+    def test_history_limit_int(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_DEFAULT_HISTORY_LIMIT": "100"})
+        assert cfg.default_history_limit == 100
+
+    def test_history_limit_invalid_falls_back(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_DEFAULT_HISTORY_LIMIT": "abc"})
+        assert cfg.default_history_limit == 20
+
+    def test_history_limit_zero_clamped_to_one(self):
+        cfg = BlqRuntimeConfig.from_env(env={"BLQ_DEFAULT_HISTORY_LIMIT": "0"})
+        assert cfg.default_history_limit == 1
+
+
+class TestUpdateRuntime:
+    def test_set_active_root_persists_in_singleton(self):
+        update_runtime({"active_root": "/tmp/x"})
+        assert get_runtime().active_root == "/tmp/x"
+
+    def test_unknown_key_raises_and_leaves_unchanged(self):
+        original = get_runtime().to_dict()
+        with pytest.raises(ValueError, match="unknown config key"):
+            update_runtime({"bogus": "value"})
+        assert get_runtime().to_dict() == original
+
+    def test_invalid_value_raises_and_leaves_unchanged(self):
+        original = get_runtime().to_dict()
+        with pytest.raises(ValueError, match="log_level"):
+            update_runtime({"log_level": "verbose"})
+        assert get_runtime().to_dict() == original
+
+    def test_atomic_batch_set_either_all_or_none(self):
+        original = get_runtime().to_dict()
+        with pytest.raises(ValueError):
+            update_runtime({"active_root": "/tmp/y", "log_level": "verbose"})
+        # active_root should NOT have been applied even though it's valid
+        assert get_runtime().to_dict() == original
+
+    def test_history_limit_rejects_string(self):
+        with pytest.raises(ValueError, match="default_history_limit"):
+            update_runtime({"default_history_limit": "50"})
+
+    def test_history_limit_rejects_bool(self):
+        with pytest.raises(ValueError, match="default_history_limit"):
+            update_runtime({"default_history_limit": True})
+
+    def test_history_limit_rejects_zero(self):
+        with pytest.raises(ValueError, match="default_history_limit"):
+            update_runtime({"default_history_limit": 0})
+
+    def test_lines_window_accepts_empty_string(self):
+        update_runtime({"default_lines_window": ""})
+        assert get_runtime().default_lines_window == ""
+
+
+class TestResetRuntime:
+    def test_reset_reverts_to_seed(self, monkeypatch):
+        monkeypatch.setenv("BLQ_ACTIVE_ROOT", "/tmp/seeded")
+        rt._seed = BlqRuntimeConfig.from_env()
+        rt._runtime = BlqRuntimeConfig.from_env()
+        update_runtime({"active_root": "/tmp/overridden"})
+        assert get_runtime().active_root == "/tmp/overridden"
+        reset_runtime()
+        assert get_runtime().active_root == "/tmp/seeded"
+
+    def test_reset_with_no_env_goes_to_defaults(self):
+        update_runtime({"active_root": "/tmp/x", "default_history_limit": 200})
+        reset_runtime()
+        assert get_runtime().active_root is None
+        assert get_runtime().default_history_limit == 20
+
+
+class TestResolveStorageRoot:
+    def test_returns_none_when_unset(self):
+        assert resolve_storage_root() is None
+
+    def test_returns_active_root_when_set(self):
+        update_runtime({"active_root": "/tmp/somewhere"})
+        assert resolve_storage_root() == "/tmp/somewhere"
+
+
+class TestConfigToolViaMCP:
+    """Smoke tests for the registered MCP tool."""
+
+    def test_config_is_registered(self):
+        pytest.importorskip("fastmcp")
+        import asyncio
+        from fastmcp import Client
+        from blq.serve import mcp
+
+        async def _list():
+            async with Client(mcp) as client:
+                tools = await client.list_tools()
+                return [t.name for t in tools]
+
+        loop = asyncio.new_event_loop()
+        try:
+            names = loop.run_until_complete(_list())
+        finally:
+            loop.close()
+        assert "config" in names
+
+    def test_call_returns_current_state(self):
+        pytest.importorskip("fastmcp")
+        import asyncio
+        from fastmcp import Client
+        from blq.serve import mcp
+
+        async def _call():
+            async with Client(mcp) as client:
+                return await client.call_tool("config", {})
+
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(_call())
+        finally:
+            loop.close()
+        # FastMCP wraps the dict; pull data or text out
+        data = getattr(result, "data", None) or getattr(result, "structured_content", None)
+        if data is None and hasattr(result, "content"):
+            data = result.content[0].text
+        assert "active_root" in str(data)


### PR DESCRIPTION
Mirrors jetsam PR #13 and squackit PR #6 — third server in the suite-wide config() convention. In-memory only, env-seeded, atomic batched-set. Persistent state stays in the DB. 22 tests added; full suite 1326 green. See retritis bench/config-endpoint-plan.md for the cross-suite design.