### PR TITLE
Route import/capture to the active storage backend; widen capture COLUMNS

### DIFF
--- a/src/blq/commands/execution.py
+++ b/src/blq/commands/execution.py
@@ -45,7 +45,7 @@ from blq.commands.core import (
     parse_log_content,
     write_run_parquet,
 )
-from blq.ext import CommandSpec
+from blq.ext import CommandSpec, capture_env
 from blq.ext.discovery import load_extensions, order_extensions
 from blq.ext.local_executor import LocalExecutor
 from blq.ext.pipeline import run_pipeline
@@ -772,6 +772,7 @@ def _execute_command(
             stderr=subprocess.STDOUT,
             text=True,
             start_new_session=True,
+            env=capture_env(),
         )
 
         output_lines: list[str] = []
@@ -1137,6 +1138,7 @@ def _run_no_capture(command: str, quiet: bool = False) -> int:
             stderr=subprocess.STDOUT,
             text=True,
             start_new_session=True,
+            env=capture_env(),
         )
 
         assert process.stdout is not None  # stdout=PIPE ensures this
@@ -1559,6 +1561,39 @@ def cmd_exec(args: argparse.Namespace) -> None:
     sys.exit(result.exit_code)
 
 
+def _write_imported_run(
+    events: list[dict[str, Any]],
+    run_meta: dict[str, Any],
+    config: "BlqConfig",
+    lq_dir: Path,
+) -> Path | str:
+    """Persist an imported/captured run to the ACTIVE storage backend.
+
+    `import` and `capture` used to call `write_run_parquet` unconditionally,
+    while `exec`/`run` branch on `config.use_bird`. BIRD is the default storage
+    mode, so on a default project those two commands wrote a well-formed
+    parquet under `.bird/logs/` that the query layer — a view over the BIRD
+    tables — never reads:
+
+        $ blq import report.json --format pytest_json
+        Imported 2 events (2 errors, 0 warnings)
+        Saved to .bird/logs/date=.../source=import/001_report.parquet
+        $ blq events
+        (no data)
+
+    Success, a destination path, exit 0, a real file, and nothing observable.
+    The branch was added to the exec path and never to these two.
+
+    Raw output is deliberately not stored here: neither command previously
+    retained it, and this function is fixing where events land, not what else
+    gets kept.
+    """
+    if config.use_bird:
+        _invocation_id, db_path = write_bird_invocation(events, run_meta, lq_dir)
+        return db_path
+    return write_run_parquet(events, run_meta, lq_dir)
+
+
 def cmd_import(args: argparse.Namespace) -> None:
     """Import an existing log file."""
     config = BlqConfig.ensure()
@@ -1587,7 +1622,7 @@ def cmd_import(args: argparse.Namespace) -> None:
         "exit_code": 0,
     }
 
-    outpath = write_run_parquet(events, run_meta, lq_dir)
+    outpath = _write_imported_run(events, run_meta, config, lq_dir)
 
     errors = sum(1 for e in events if e.get("severity") == "error")
     warnings = sum(1 for e in events if e.get("severity") == "warning")
@@ -1620,7 +1655,7 @@ def cmd_capture(args: argparse.Namespace) -> None:
         "exit_code": 0,
     }
 
-    outpath = write_run_parquet(events, run_meta, lq_dir)
+    outpath = _write_imported_run(events, run_meta, config, lq_dir)
 
     errors = sum(1 for e in events if e.get("severity") == "error")
     warnings = sum(1 for e in events if e.get("severity") == "warning")

--- a/src/blq/commands/execution.py
+++ b/src/blq/commands/execution.py
@@ -1566,7 +1566,7 @@ def _write_imported_run(
     run_meta: dict[str, Any],
     config: "BlqConfig",
     lq_dir: Path,
-) -> Path | str:
+) -> Path:
     """Persist an imported/captured run to the ACTIVE storage backend.
 
     `import` and `capture` used to call `write_run_parquet` unconditionally,

--- a/src/blq/ext/__init__.py
+++ b/src/blq/ext/__init__.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol
 
+import os
+
 
 @dataclass
 class CommandSpec:
@@ -83,3 +85,32 @@ class Executor(Protocol):
     name: str
 
     def execute(self, spec: CommandSpec) -> ExecutionResult: ...
+
+
+#: Terminal width presented to captured child processes. Wide enough that the
+#: tools we parse stop abbreviating; not so wide that a tool wrapping to it
+#: produces unreadable raw logs.
+CAPTURE_COLUMNS = 200
+
+
+def capture_env(base: dict[str, str] | None = None) -> dict[str, str]:
+    """Environment for a captured child process.
+
+    Anything that formats for a terminal consults COLUMNS (or an ioctl) and
+    falls back to 80 columns when there is no TTY — which is always, under a
+    capturing runner. `pytest -q` abbreviates its short-summary line on that
+    basis, and since blq parses that line, the stored message loses everything
+    past roughly 80 columns minus the length of the test name:
+
+        73-char test name  ->   7 characters survive ('asse...')
+        35-char test name  ->  45 characters survive, nothing is lost
+
+    So how diagnosable a failure was depended on how long someone had named
+    the test. Presenting a wide COLUMNS fixes the whole class at the point of
+    capture — no parser can recover text the tool never printed.
+
+    An explicit COLUMNS from the caller wins: someone who set it meant it.
+    """
+    env = dict(os.environ if base is None else base)
+    env.setdefault("COLUMNS", str(CAPTURE_COLUMNS))
+    return env

--- a/src/blq/ext/local_executor.py
+++ b/src/blq/ext/local_executor.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from pathlib import Path
 from types import FrameType
 
-from blq.ext import CommandSpec, ExecutionResult
+from blq.ext import CommandSpec, ExecutionResult, capture_env
 
 logger = logging.getLogger("blq-ext")
 
@@ -78,7 +78,9 @@ class LocalExecutor:
             signal.signal(signal.SIGINT, _cleanup)
             signal.signal(signal.SIGTERM, _cleanup)
 
-            run_env = {**os.environ, **spec.env} if spec.env else None
+            # Always via capture_env: a captured child has no TTY, so
+            # terminal-formatting tools self-truncate at 80 columns.
+            run_env = capture_env({**os.environ, **spec.env} if spec.env else None)
             process = subprocess.Popen(
                 spec.command,
                 shell=True,

--- a/src/blq_sandbox/profile.py
+++ b/src/blq_sandbox/profile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shlex
 import shutil
 import subprocess
@@ -78,12 +79,26 @@ def run_profile(
             "--",
             *command_argv,
         ]
+        # Present a wide terminal to the traced command, for the same reason
+        # blq.ext.capture_env does: a captured child has no TTY, so anything
+        # that formats for a terminal self-truncates at an assumed 80 columns.
+        #
+        # Set locally rather than imported. blq_sandbox is registered as an
+        # extension through entry points and deliberately does not import from
+        # `blq`; pulling in blq.ext.capture_env here would couple two packages
+        # that are independent today. This path profiles syscalls and discards
+        # the command's stdout, so nothing depends on the width now — it is set
+        # so that surfacing this output later cannot silently reintroduce the
+        # truncation.
+        profile_env = dict(os.environ)
+        profile_env.setdefault("COLUMNS", "200")
         try:
             subprocess.run(
                 strace_cmd,
                 timeout=timeout,
                 check=False,
                 capture_output=True,
+                env=profile_env,
             )
         except subprocess.TimeoutExpired:
             logger.warning(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -511,9 +511,18 @@ Done
         captured = capsys.readouterr()
         assert "Imported" in captured.out or "Captured" in captured.out
 
-        # Check parquet was created
-        parquet_files = list(Path(".bird/logs").rglob("*.parquet"))
-        assert len(parquet_files) >= 1
+        # Assert the events are QUERYABLE, not that a file appeared.
+        #
+        # This used to check for a parquet under .bird/logs/. That assertion
+        # held throughout the period when `import` wrote parquet in BIRD mode
+        # — the default — where the query layer reads the BIRD tables and
+        # never looks at those files. A well-formed but unreadable artifact
+        # satisfied it, so the suite reported health while every import on a
+        # default project was stranded. Storage location is an implementation
+        # detail; reading back what you imported is the requirement.
+        conn = get_connection(Path(".bird"))
+        count = conn.execute("SELECT count(*) FROM blq_load_events()").fetchone()[0]
+        assert count >= 1
 
 
 class TestCmdEvent:

--- a/tests/test_import_capture_storage.py
+++ b/tests/test_import_capture_storage.py
@@ -1,0 +1,196 @@
+"""`import` and `capture` must write where the query layer reads.
+
+Both commands called `write_run_parquet` unconditionally, while `exec`/`run`
+branch on `config.use_bird` and write to the BIRD tables. Since BIRD is the
+default storage mode, an import on a default project produced a valid parquet
+under `.bird/logs/date=*/source=import/` that nothing could read:
+
+    $ blq import report.json --format pytest_json
+    Imported 2 events (2 errors, 0 warnings)
+    Saved to .bird/logs/date=2026-08-17/source=import/001_report.parquet
+    $ blq events
+    (no data)
+
+Success reported, destination printed, exit 0, well-formed file — and no
+observable outcome. The only signal available to a caller is a query they have
+no reason to run as a check.
+
+That mattered most for the richest source in the pipeline: a `pytest_json`
+import carries the whole failure block (assertion, source line, and the
+`+ where None = normalize(...)` line naming the function under test) where a
+default text capture of the same run carries a 7-character fragment.
+
+Covers both commands in both storage modes — parquet mode must keep writing
+parquet, which is the behaviour these tests are protecting on that side.
+"""
+
+import argparse
+
+import pytest
+
+from blq.commands.execution import cmd_capture, cmd_import
+
+
+PYTEST_TEXT_LOG = """\
+============================= test session starts ==============================
+collected 1 item
+
+tests/test_priority.py F                                                 [100%]
+
+=================================== FAILURES ===================================
+____________________ test_unknown_name_falls_back_to_default ___________________
+
+    def test_unknown_name_falls_back_to_default():
+>       assert normalize(5) == 5
+E       assert None == 5
+E        +  where None = normalize(5)
+
+tests/test_priority.py:5: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_priority.py::test_unknown_name_falls_back_to_default - assert None == 5
+1 failed in 0.01s
+"""
+
+
+def _import_args(path, fmt="pytest_text", name=None):
+    args = argparse.Namespace()
+    args.file = str(path)
+    args.format = fmt
+    args.name = name
+    return args
+
+
+def _capture_args(fmt="pytest_text", name=None):
+    args = argparse.Namespace()
+    args.format = fmt
+    args.name = name
+    return args
+
+
+def _event_count(project):
+    """Rows visible through the query layer callers actually use."""
+    from blq.commands.core import get_connection
+
+    conn = get_connection(project / ".bird")
+    return conn.execute("SELECT count(*) FROM blq_load_events()").fetchone()[0]
+
+
+@pytest.fixture
+def log_file(tmp_path):
+    p = tmp_path / "pytest-run.log"
+    p.write_text(PYTEST_TEXT_LOG)
+    return p
+
+
+class TestImportIsQueryable:
+
+    def test_imported_events_are_visible_in_bird_mode(
+        self, initialized_project, log_file, capsys
+    ):
+        cmd_import(_import_args(log_file))
+        capsys.readouterr()
+        assert _event_count(initialized_project) > 0, (
+            "import reported success and wrote a file, but the query layer "
+            "sees nothing"
+        )
+
+    def test_imported_events_are_visible_in_parquet_mode(
+        self, initialized_project_parquet, log_file, capsys
+    ):
+        cmd_import(_import_args(log_file))
+        capsys.readouterr()
+        assert _event_count(initialized_project_parquet) > 0
+
+    def test_the_error_message_survives_the_round_trip(
+        self, initialized_project, log_file, capsys
+    ):
+        """The point of importing is the diagnostic text, so assert on it.
+
+        The fixture carries an UNtruncated summary line — what pytest emits
+        when it is not abbreviating for an 80-column terminal it cannot see.
+        The parser reads that line, so an abbreviated one would make this
+        assert on text pytest had already discarded rather than on anything
+        blq did.
+        """
+        from blq.commands.core import get_connection
+
+        cmd_import(_import_args(log_file))
+        capsys.readouterr()
+        conn = get_connection(initialized_project / ".bird")
+        rows = conn.execute(
+            "SELECT message FROM blq_load_events() WHERE severity = 'error'"
+        ).fetchall()
+        assert rows, "no error events queryable after import"
+        assert any("assert" in (r[0] or "").lower() for r in rows), rows
+
+
+class TestCaptureIsQueryable:
+    """`capture` shares the same unconditional parquet write as `import`."""
+
+    def test_captured_events_are_visible_in_bird_mode(
+        self, initialized_project, monkeypatch, capsys
+    ):
+        import io
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(PYTEST_TEXT_LOG))
+        cmd_capture(_capture_args())
+        capsys.readouterr()
+        assert _event_count(initialized_project) > 0
+
+    def test_captured_events_are_visible_in_parquet_mode(
+        self, initialized_project_parquet, monkeypatch, capsys
+    ):
+        import io
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(PYTEST_TEXT_LOG))
+        cmd_capture(_capture_args())
+        capsys.readouterr()
+        assert _event_count(initialized_project_parquet) > 0
+
+
+# ── Captured children get a usable terminal width (#49) ──────────────
+
+
+class TestCaptureEnvironment:
+    """Tools that format for a terminal self-truncate when captured.
+
+    pytest consults COLUMNS and falls back to 80 when there is no TTY — which
+    is always, under a capturing runner. `pytest -q` abbreviates its
+    short-summary line on that basis, so the parsed message loses everything
+    past roughly 80 columns minus the length of the test name:
+
+        73-char test name  ->  7 characters of message survive ('asse...')
+        35-char test name  -> 45 characters survive, nothing is lost
+
+    A failure's diagnosability therefore depended on how long its test was
+    named, which is not a dependency anyone would guess. Presenting a wide
+    COLUMNS to the child fixes the whole class at the point of capture,
+    rather than each parser trying to recover text the tool already discarded.
+    """
+
+    def test_columns_is_set_wide_by_default(self):
+        from blq.ext import capture_env
+
+        env = capture_env({"PATH": "/usr/bin"})
+        assert int(env["COLUMNS"]) >= 200
+
+    def test_an_explicit_columns_is_respected(self):
+        """A caller who set COLUMNS meant it — including a narrow one."""
+        from blq.ext import capture_env
+
+        env = capture_env({"PATH": "/usr/bin", "COLUMNS": "40"})
+        assert env["COLUMNS"] == "40"
+
+    def test_the_rest_of_the_environment_survives(self):
+        from blq.ext import capture_env
+
+        env = capture_env({"PATH": "/usr/bin", "MY_VAR": "keep me"})
+        assert env["PATH"] == "/usr/bin"
+        assert env["MY_VAR"] == "keep me"
+
+    def test_the_caller_environment_is_not_mutated(self):
+        from blq.ext import capture_env
+
+        original = {"PATH": "/usr/bin"}
+        capture_env(original)
+        assert "COLUMNS" not in original


### PR DESCRIPTION
Fixes #50 and #49. Both are commands that report success while losing data.

## #50 — `import`/`capture` wrote parquet the query layer cannot read

`cmd_import` and `cmd_capture` called `write_run_parquet` unconditionally, while `exec`/`run` branch on `config.use_bird`. BIRD is the default, so on a default project:

```
$ blq import report.json --format pytest_json
Imported 2 events (2 errors, 0 warnings)
Saved to .bird/logs/date=.../source=import/001_report.parquet
$ blq events
(no data)
```

Success, a destination path, exit 0, a well-formed file, nothing observable. The backend branch was added to the exec path and never to these two.

What it stranded matters: a `pytest_json` import carries the full failure block — assertion, source line, and the `+ where None = normalize(...)` line naming **the function under test** — **184 characters**, against **7** from a default text capture of the same run.

Both commands now go through `_write_imported_run`, which honours the configured backend. Parquet mode is unchanged.

## #49 — captured children were told the terminal was 80 columns

Tools that format for a terminal consult `COLUMNS` and fall back to 80 without a TTY — always, under capture. `pytest -q` abbreviates its summary line on that basis and blq parses that line, so:

| test name length | message surviving |
|---|---|
| 73 chars | **7** — `asse...` |
| 35 chars | 45 — nothing lost |

A failure's diagnosability depended on how long someone had named the test. Captured children now get `COLUMNS=200` unless the caller set one (an explicit `COLUMNS=80` still truncates — that's a deliberate choice).

Placed in `blq.ext.capture_env` so it covers `LocalExecutor` — the path `exec`/`run` actually take — as well as the two direct `Popen` sites. `ext/` keeps its layering and does not import from `commands/`.

## Verification

```
default capture:  7 -> 16 chars (full message)
COLUMNS=80:       7 chars (override respected)
pytest_json import: not queryable -> 184-char message queryable
```

Full suite **1354 passed** (baseline 1345 + 9 new). One existing test changed: `TestCmdImport::test_imports_log_file` asserted a parquet file appeared, which held for the entire life of the storage bug because an unreadable artifact satisfied it. It now asserts the events are queryable.

## Not included

#48 (`related_files` from traceback frames) is untouched — the frames are parsed by duck_hunt, which I haven't read, and I didn't want to guess at another project's parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JAindVccsTsdMTx3SV1iU