### PR TITLE
fix: persist duck_hunt's log_content in both storage backends (#52)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,7 +560,7 @@ Pre-built prompts that guide agents through common workflows:
   "file_path": "src/main.c",
   "line_number": 15,
   "message": "undefined variable 'foo'",
-  "raw_text": "src/main.c:15:5: error: use of undeclared identifier 'foo'",
+  "log_content": "src/main.c:15:5: error: use of undeclared identifier 'foo'",
   "fingerprint": "abc123...",
   "cwd": "/home/user/project",
   "hostname": "dev-machine",

--- a/docs/design/duck-hunt-v3-migration.md
+++ b/docs/design/duck-hunt-v3-migration.md
@@ -4,6 +4,10 @@
 
 This document outlines the changes needed to migrate blq to duck_hunt's Schema V3.
 
+> **Status:** the `ref_*` renames and the `raw_text` -> `log_content` rename have
+> landed (the latter in #52, which also began populating the column in both
+> storage backends). The `log_file` field is still not persisted.
+
 ## Key Changes
 
 ### 1. Field Renames

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -86,6 +86,7 @@ Parsed diagnostics (errors, warnings, test results).
 | `fingerprint` | VARCHAR | Unique identifier for deduplication |
 | `log_line_start` | INTEGER | Start line in raw log |
 | `log_line_end` | INTEGER | End line in raw log |
+| `log_content` | VARCHAR | Raw log block for this event (e.g. the whole pytest FAILURES block); capped at 32768 chars, with a visible marker when truncated |
 | `context` | VARCHAR | Surrounding context |
 | `metadata` | JSON | Format-specific extras |
 | `format_used` | VARCHAR | Parser format (gcc, cargo, pytest) |

--- a/src/blq/bird.py
+++ b/src/blq/bird.py
@@ -32,6 +32,34 @@ logger = logging.getLogger("blq-bird")
 # Type variable for retry function
 T = TypeVar("T")
 
+# Current BIRD schema version. Must match the value seeded by bird_schema.sql;
+# _needs_repair/_apply_migrations compare a database's stored version against it.
+SCHEMA_VERSION = "3.1.0"
+
+
+def _version_tuple(version: str) -> tuple[int, int]:
+    """(major, minor) of a version string, or (0, 0) if unparseable."""
+    try:
+        parts = [int(p) for p in version.split(".")]
+    except (ValueError, AttributeError):
+        return (0, 0)
+    if not parts:
+        return (0, 0)
+    return (parts[0], parts[1] if len(parts) > 1 else 0)
+
+
+LATEST_SCHEMA = _version_tuple(SCHEMA_VERSION)
+
+# Columns that must exist on a table regardless of the recorded schema version.
+# A migration can fail silently (DuckDB blocks ALTER while views depend on the
+# table) and let the version advance past itself, so these are also checked
+# directly and re-added by _reconcile_schema.
+REQUIRED_COLUMNS: dict[str, dict[str, str]] = {
+    "attempts": {"extension_data": "JSON"},
+    "invocations": {"extension_data": "JSON"},
+    "events": {"log_content": "VARCHAR"},
+}
+
 # Default retry settings for lock contention
 DEFAULT_MAX_RETRIES = 5
 DEFAULT_INITIAL_DELAY = 0.05  # 50ms
@@ -99,8 +127,9 @@ def retry_on_lock(
     raise last_error
 
 
-# Schema version
-BIRD_SCHEMA_VERSION = "2.1.0"
+# (BIRD_SCHEMA_VERSION used to live here, hardcoded at "2.1.0" and read by
+# nothing — a second, stale version constant. SCHEMA_VERSION above is the one
+# the schema file and the migrations agree on.)
 
 # Storage thresholds (per BIRD spec)
 DEFAULT_INLINE_THRESHOLD = 4096  # 4KB - outputs smaller than this are stored inline
@@ -528,22 +557,23 @@ class BirdStore:
         try:
             parts = [int(p) for p in current_version.split(".")]
             major, minor = parts[0], parts[1] if len(parts) > 1 else 0
-            if (major, minor) < (3, 0):
+            if (major, minor) < LATEST_SCHEMA:
                 return True
         except (ValueError, IndexError):
             return True  # unparseable version — reconcile to be safe
         # Self-heal for migrations that failed silently on dependent views and
         # then let the version advance past themselves (leaving no column).
-        for table in ("attempts", "invocations"):
-            try:
-                has = conn.execute(
-                    "SELECT 1 FROM information_schema.columns "
-                    f"WHERE table_name = '{table}' AND column_name = 'extension_data'"
-                ).fetchone()
-                if not has:
+        for table, required in REQUIRED_COLUMNS.items():
+            for column in required:
+                try:
+                    has = conn.execute(
+                        "SELECT 1 FROM information_schema.columns "
+                        f"WHERE table_name = '{table}' AND column_name = '{column}'"
+                    ).fetchone()
+                    if not has:
+                        return True
+                except duckdb.Error:
                     return True
-            except duckdb.Error:
-                return True
         return False
 
     @staticmethod
@@ -553,8 +583,7 @@ class BirdStore:
         to recreate them."""
         try:
             views = conn.execute(
-                "SELECT table_name FROM information_schema.tables "
-                "WHERE table_type = 'VIEW'"
+                "SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW'"
             ).fetchall()
         except duckdb.Error:
             return
@@ -566,19 +595,19 @@ class BirdStore:
 
     @classmethod
     def _reconcile_schema(cls, conn: duckdb.DuckDBPyConnection) -> None:
-        """Version-independent self-heal: ensure `extension_data` exists on
-        attempts and invocations even if a past migration failed silently (blocked
-        by dependent views) and the schema version advanced past it. Views must
-        already be dropped by the caller so the ALTER/RENAME can proceed.
+        """Version-independent self-heal: ensure every column in REQUIRED_COLUMNS
+        exists, even if the migration that should have added it failed silently
+        (blocked by dependent views) and the schema version advanced past it.
+        Views must already be dropped by the caller so the ALTER can proceed.
 
-        Uses ADD COLUMN + data copy, NOT rename: RENAME COLUMN on these tables is
-        blocked by non-view dependencies (FKs/constraints) that persist even after
-        dropping views, whereas ADD COLUMN is never blocked. Existing `sandbox`
-        data (from the 2.3 migration) is copied into the new column wrapped as
-        {"sandbox": ...}; the now-redundant `sandbox` column is left in place
-        (harmless, and DROP COLUMN hits the same dependency wall).
+        Uses ADD COLUMN, NOT rename: RENAME COLUMN on these tables is blocked by
+        non-view dependencies (FKs/constraints) that persist even after dropping
+        views, whereas ADD COLUMN is never blocked. For `extension_data`,
+        existing `sandbox` data (from the 2.3 migration) is copied into the new
+        column wrapped as {"sandbox": ...}; the now-redundant `sandbox` column is
+        left in place (harmless, and DROP COLUMN hits the same dependency wall).
         """
-        for table in ("attempts", "invocations"):
+        for table, required in REQUIRED_COLUMNS.items():
             try:
                 cols = {
                     r[0]
@@ -587,21 +616,26 @@ class BirdStore:
                         f"WHERE table_name = '{table}'"
                     ).fetchall()
                 }
-                if "extension_data" in cols:
-                    continue
-                conn.execute(f"ALTER TABLE {table} ADD COLUMN extension_data JSON")
-                if "sandbox" in cols:
-                    conn.execute(
-                        f"UPDATE {table} SET extension_data = "
-                        f"json_object('sandbox', sandbox) WHERE sandbox IS NOT NULL"
-                    )
-                    logger.info(
-                        f"Repaired {table}: added extension_data (copied sandbox data)"
-                    )
-                else:
-                    logger.info(f"Repaired {table}: added extension_data")
             except duckdb.Error as e:
                 logger.warning(f"Schema reconcile warning ({table}): {e}")
+                continue
+            if not cols:
+                continue  # table doesn't exist yet; the schema file will create it
+            for column, column_type in required.items():
+                if column in cols:
+                    continue
+                try:
+                    conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_type}")
+                    if column == "extension_data" and "sandbox" in cols:
+                        conn.execute(
+                            f"UPDATE {table} SET extension_data = "
+                            f"json_object('sandbox', sandbox) WHERE sandbox IS NOT NULL"
+                        )
+                        logger.info(f"Repaired {table}: added extension_data (copied sandbox data)")
+                    else:
+                        logger.info(f"Repaired {table}: added {column}")
+                except duckdb.Error as e:
+                    logger.warning(f"Schema reconcile warning ({table}.{column}): {e}")
 
     @classmethod
     def _apply_migrations(cls, conn: duckdb.DuckDBPyConnection, current_version: str) -> None:
@@ -670,6 +704,16 @@ class BirdStore:
         if (major, minor) < (3, 0):
             conn.execute("UPDATE blq_metadata SET value = '3.0.0' WHERE key = 'schema_version'")
             logger.info("Migration: Updated schema version to 3.0.0 (BIRD directory)")
+
+        # Migration: 3.0.0 -> 3.1.0 (add events.log_content — duck_hunt's raw
+        # block for the event, previously received and dropped; see #52).
+        # _reconcile_schema does the ADD COLUMN and is idempotent, so it also
+        # covers a DB whose version advanced without the column landing.
+        if (major, minor) < (3, 1):
+            cls._reconcile_schema(conn)
+            migrations_applied = True
+            conn.execute("UPDATE blq_metadata SET value = '3.1.0' WHERE key = 'schema_version'")
+            logger.info("Migration: Added log_content column to events table")
 
         # If migrations were applied, reload views/macros to pick up new columns
         if migrations_applied:
@@ -1583,6 +1627,10 @@ class BirdStore:
         if not events:
             return 0
 
+        # Local import: core imports nothing from bird at module scope, and this
+        # mirrors the existing lazy-import pattern used elsewhere in this module.
+        from blq.commands.core import truncate_log_content
+
         date = datetime.now().strftime("%Y-%m-%d")
 
         for idx, event in enumerate(events):
@@ -1594,10 +1642,10 @@ class BirdStore:
                     id, invocation_id, event_index, client_id, hostname,
                     event_type, severity, ref_file, ref_line, ref_column,
                     message, code, rule, tool_name, category, test_name,
-                    fingerprint, log_line_start, log_line_end, context,
-                    metadata, format_used, date
+                    fingerprint, log_line_start, log_line_end, log_content,
+                    context, metadata, format_used, date
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     event_id,
@@ -1619,6 +1667,7 @@ class BirdStore:
                     event.get("fingerprint"),
                     event.get("log_line_start"),
                     event.get("log_line_end"),
+                    truncate_log_content(event.get("log_content")),
                     event.get("context"),
                     json.dumps(event.get("metadata")) if event.get("metadata") else None,
                     format_used,

--- a/src/blq/bird_schema.sql
+++ b/src/blq/bird_schema.sql
@@ -26,7 +26,8 @@ CREATE TABLE IF NOT EXISTS blq_metadata (
 );
 
 -- Insert schema version (ignore if exists)
-INSERT OR IGNORE INTO blq_metadata VALUES ('schema_version', '3.0.0');
+-- Keep in sync with SCHEMA_VERSION in bird.py (migrations key off it)
+INSERT OR IGNORE INTO blq_metadata VALUES ('schema_version', '3.1.0');
 INSERT OR IGNORE INTO blq_metadata VALUES ('storage_mode', 'duckdb');
 
 -- Base path for blob storage (set at runtime)
@@ -230,6 +231,7 @@ CREATE TABLE IF NOT EXISTS events (
     fingerprint       VARCHAR,                          -- Unique identifier for dedup
     log_line_start    INTEGER,                          -- Start line in raw log
     log_line_end      INTEGER,                          -- End line in raw log
+    log_content       VARCHAR,                          -- Raw log block for this event (duck_hunt log_content)
     context           VARCHAR,                          -- Surrounding context
     metadata          JSON,                             -- Format-specific extras
 
@@ -344,6 +346,7 @@ SELECT
     e.fingerprint,
     e.log_line_start,
     e.log_line_end,
+    e.log_content,
     e.context,
     e.metadata,
 

--- a/src/blq/commands/core.py
+++ b/src/blq/commands/core.py
@@ -1868,6 +1868,37 @@ def get_next_run_id(lq_dir: Path) -> int:
 
 
 # ============================================================================
+# Event content
+# ============================================================================
+
+# Cap on the stored `log_content` (duck_hunt's raw block for an event, e.g. the
+# whole pytest FAILURES block). It is bounded in practice — the block, not the
+# log — but not in principle: a parser that spans a large region, or a test that
+# dumps a large diff, can produce a very big value, and every event of a run
+# would carry its own copy. 32K is well above any realistic traceback while
+# keeping a pathological run from bloating storage.
+LOG_CONTENT_MAX_CHARS = 32_768
+
+
+def truncate_log_content(value: str | None, max_chars: int = LOG_CONTENT_MAX_CHARS) -> str | None:
+    """Cap `log_content`, making any truncation visible in the value itself.
+
+    Silent shortening has bitten this codebase before, so an over-long value
+    keeps its head and gains a marker stating what was kept and what existed:
+
+        ... [blq: log_content truncated to 32768 of 91234 chars]
+
+    Values at or under the cap are returned unchanged (including None/"").
+    """
+    if not value or len(value) <= max_chars:
+        return value
+    return (
+        value[:max_chars]
+        + f"\n... [blq: log_content truncated to {max_chars} of {len(value)} chars]"
+    )
+
+
+# ============================================================================
 # Parquet Writing
 # ============================================================================
 
@@ -1908,7 +1939,11 @@ PARQUET_SCHEMA = [
     ("ref_column", "BIGINT"),
     # Content
     ("message", "VARCHAR"),
-    ("raw_text", "VARCHAR"),
+    # duck_hunt's raw block for this event (e.g. the whole pytest FAILURES
+    # block). Replaces the vestigial `raw_text`, which nothing ever populated —
+    # duck_hunt's field has been named log_content since its Schema V3
+    # (see docs/design/duck-hunt-v3-migration.md).
+    ("log_content", "VARCHAR"),
     # Classification
     ("tool_name", "VARCHAR"),
     ("category", "VARCHAR"),
@@ -1981,6 +2016,8 @@ def write_run_parquet(
     for event in events or [{}]:
         # Merge run metadata and event data
         merged = {**run_meta, **event}
+        if merged.get("log_content"):
+            merged["log_content"] = truncate_log_content(merged["log_content"])
         # Build row with all columns in schema order
         vals = []
         for col in PARQUET_SCHEMA_COLUMNS:

--- a/src/blq/commands/migrate.py
+++ b/src/blq/commands/migrate.py
@@ -196,6 +196,7 @@ def _migrate_parquet_to_bird(
                             "fingerprint": event.get("fingerprint"),
                             "log_line_start": event.get("log_line_start"),
                             "log_line_end": event.get("log_line_end"),
+                            "log_content": event.get("log_content"),
                         }
                     )
 

--- a/src/blq/serve.py
+++ b/src/blq/serve.py
@@ -1077,7 +1077,9 @@ def _event_impl(ref: str) -> dict[str, Any] | None:
             "tool_name": event_data.get("tool_name"),
             "category": event_data.get("category"),
             "fingerprint": event_data.get("fingerprint"),
-            "raw_text": event_data.get("raw_text"),
+            # duck_hunt's raw block for this event. Was keyed "raw_text" after a
+            # column nothing ever populated, so it was always null (#52).
+            "log_content": event_data.get("log_content"),
             "log_line_start": event_data.get("log_line_start"),
             "log_line_end": event_data.get("log_line_end"),
             # Execution context

--- a/tests/test_log_content_persistence.py
+++ b/tests/test_log_content_persistence.py
@@ -1,0 +1,345 @@
+"""Tests for #52: duck_hunt's `log_content` is received and must be persisted.
+
+duck_hunt returns `log_content` carrying the whole failure block (default
+`content_mode = FULL`). blq's parser already puts it in the event dict, but
+neither storage backend had a column for it, so it was dropped at write time —
+leaving only `log_line_start`/`log_line_end`, pointers into a log that is not
+retained unless `--keep-raw`.
+
+These tests pin the field end to end (exec -> storage -> blq_load_events()) for
+both backends, the cap on oversized values, and the migration of BIRD databases
+created before the column existed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+import blq.bird as _bird_mod
+from blq.bird import BirdStore, InvocationRecord
+from blq.commands.core import (
+    LOG_CONTENT_MAX_CHARS,
+    PARQUET_SCHEMA_COLUMNS,
+    get_connection,
+    truncate_log_content,
+)
+
+SCHEMA = (Path(_bird_mod.__file__).parent / "bird_schema.sql").read_text()
+
+# A one-assertion pytest failure, verbatim from #52. The `message` duck_hunt
+# derives from the short-summary line is 7 chars ("asse..."); log_content is the
+# whole FAILURES block, including the `+  where None = normalize(5)` line that
+# names the function under test.
+PYTEST_FAILURE_LOG = """\
+============================= test session starts ==============================
+collected 1 item
+
+tests/test_priority.py F                                                 [100%]
+
+=================================== FAILURES ===================================
+________________ test_unknown_name_falls_back_to_default _______________________
+
+    def test_unknown_name_falls_back_to_default():
+>       assert normalize(5) == 5
+E       assert None == 5
+E        +  where None = normalize(5)
+
+tests/test_priority.py:5: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_priority.py::test_unknown_name_falls_back_to_default - asse...
+============================== 1 failed in 0.01s ===============================
+"""
+
+IMPLICATED_SOURCE_LINE = "+  where None = normalize(5)"
+
+
+def _failing_pytest_script(project: Path) -> list[str]:
+    """A command that reproduces the pytest output above on stdout, exit 1.
+
+    Written to a file and `cat`-ed so the block survives shell quoting exactly.
+    """
+    log_file = project / "pytest_output.txt"
+    log_file.write_text(PYTEST_FAILURE_LOG)
+    script = project / "run_pytest.sh"
+    script.write_text(f'#!/bin/bash\ncat "{log_file}"\nexit 1\n')
+    script.chmod(0o755)
+    return [str(script)]
+
+
+def _cols(conn, table):
+    return {
+        r[0]
+        for r in conn.execute(
+            f"SELECT column_name FROM information_schema.columns WHERE table_name='{table}'"
+        ).fetchall()
+    }
+
+
+def _apply(conn, sql_text):
+    for stmt in BirdStore._split_sql_statements(sql_text):
+        try:
+            conn.execute(stmt)
+        except duckdb.Error:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# End to end: exec -> storage -> blq_load_events()
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndPersistence:
+    def test_bird_exec_persists_log_content(self, initialized_project, run_adhoc_command):
+        """BIRD mode: the failure block survives to blq_load_events()."""
+        run_adhoc_command(_failing_pytest_script(initialized_project), format="pytest_text")
+
+        conn = get_connection(Path(".bird"))
+        row = conn.execute(
+            "SELECT message, log_content FROM blq_load_events() WHERE severity = 'error'"
+        ).fetchone()
+
+        assert row is not None, "no error event was stored"
+        message, log_content = row
+        assert log_content, "log_content was dropped at write time"
+        assert IMPLICATED_SOURCE_LINE in log_content
+        assert "assert None == 5" in log_content
+        assert len(log_content) > len(message or "")
+
+    def test_parquet_exec_persists_log_content(
+        self, initialized_project_parquet, run_adhoc_command
+    ):
+        """Legacy parquet mode: same guarantee, same column name."""
+        run_adhoc_command(_failing_pytest_script(initialized_project_parquet), format="pytest_text")
+
+        conn = get_connection(Path(".bird"))
+        row = conn.execute(
+            "SELECT message, log_content FROM blq_load_events() WHERE severity = 'error'"
+        ).fetchone()
+
+        assert row is not None, "no error event was stored"
+        message, log_content = row
+        assert log_content, "log_content was dropped at write time"
+        assert IMPLICATED_SOURCE_LINE in log_content
+        assert len(log_content) > len(message or "")
+
+
+# ---------------------------------------------------------------------------
+# Schema shape
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaShape:
+    def test_parquet_schema_has_log_content_and_no_vestigial_raw_text(self):
+        """`raw_text` was never populated by anything; log_content replaces it.
+
+        docs/design/duck-hunt-v3-migration.md records this exact rename as the
+        intended migration (`raw_text` -> `log_content`).
+        """
+        assert "log_content" in PARQUET_SCHEMA_COLUMNS
+        assert "raw_text" not in PARQUET_SCHEMA_COLUMNS
+
+    def test_bird_events_table_has_log_content(self, tmp_path):
+        bird = tmp_path / ".bird"
+        bird.mkdir()
+        conn = duckdb.connect(str(bird / "blq.duckdb"))
+        BirdStore._ensure_schema(conn, bird)
+        assert "log_content" in _cols(conn, "events")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Cap: bounded, and visibly truncated rather than silently
+# ---------------------------------------------------------------------------
+
+
+class TestCap:
+    def test_short_values_pass_through_unchanged(self):
+        assert truncate_log_content(PYTEST_FAILURE_LOG) == PYTEST_FAILURE_LOG
+        assert truncate_log_content(None) is None
+        assert truncate_log_content("") == ""
+
+    def test_oversized_values_are_capped_and_say_so(self):
+        oversized = "x" * (LOG_CONTENT_MAX_CHARS + 5000)
+        result = truncate_log_content(oversized)
+
+        assert len(result) < len(oversized)
+        assert "truncated" in result
+        # The marker must state both the kept and the original size, so a reader
+        # can tell how much is missing.
+        assert str(len(oversized)) in result
+        assert str(LOG_CONTENT_MAX_CHARS) in result
+        assert result.startswith("x" * 100)
+
+    def test_bird_write_events_applies_the_cap(self, tmp_path):
+        bird = tmp_path / ".bird"
+        bird.mkdir()
+        with BirdStore.open(bird) as store:
+            store.ensure_session("s", "blq-test", "blq", "cli")
+            inv = InvocationRecord(
+                id="00000000-0000-0000-0000-000000000001",
+                session_id="s",
+                cmd="pytest",
+                cwd="/tmp",
+                exit_code=1,
+                client_id="blq-test",
+                source_name="test",
+            )
+            store.write_invocation(inv)
+            store.write_events(
+                inv.id,
+                [{"severity": "error", "message": "boom", "log_content": "y" * 999_999}],
+                client_id="blq-test",
+            )
+            stored = store.connection.execute("SELECT log_content FROM events").fetchone()[0]
+
+        assert len(stored) <= LOG_CONTENT_MAX_CHARS + 200  # value + marker
+        assert "truncated" in stored
+
+
+# ---------------------------------------------------------------------------
+# Migration of databases created before the column existed
+# ---------------------------------------------------------------------------
+
+
+def _schema_without_log_content() -> str:
+    """The schema as it was before log_content existed.
+
+    Rebuilding the old schema is how the pre-existing repair tests simulate an
+    older era; DROP COLUMN is not usable here because DuckDB refuses to drop a
+    column that an index sits after.
+    """
+    lines = [
+        line
+        for line in SCHEMA.splitlines(keepends=True)
+        if line.strip() not in ("e.log_content,",) and not line.strip().startswith("log_content ")
+    ]
+    text = "".join(lines)
+    assert "log_content" not in text, "failed to strip log_content from schema"
+    return text
+
+
+def _build_pre_log_content_db(path: Path) -> None:
+    """A healthy DB from before log_content existed: schema at 3.0.0, events
+    table without the column, and one event row already in it."""
+    conn = duckdb.connect(str(path))
+    _apply(conn, _schema_without_log_content())
+    conn.execute(
+        "INSERT INTO invocations (id, session_id, cmd, cwd, client_id, exit_code, source_name) "
+        "VALUES ('00000000-0000-0000-0000-0000000000aa', 's1', 'pytest', '/tmp', "
+        "'blq-test', 1, 'test')"
+    )
+    conn.execute(
+        "INSERT INTO events (invocation_id, event_index, client_id, severity, message) "
+        "VALUES ('00000000-0000-0000-0000-0000000000aa', 0, 'blq-test', 'error', 'old event')"
+    )
+    conn.execute("UPDATE blq_metadata SET value='3.0.0' WHERE key='schema_version'")
+    conn.close()
+
+
+class TestMigration:
+    def test_existing_db_gains_the_column_without_losing_rows(self, tmp_path):
+        bird = tmp_path / ".bird"
+        bird.mkdir()
+        db = bird / "blq.duckdb"
+        _build_pre_log_content_db(db)
+
+        conn = duckdb.connect(str(db))
+        assert "log_content" not in _cols(conn, "events")
+        assert BirdStore._needs_repair(conn, "3.0.0") is True
+
+        BirdStore._ensure_schema(conn, bird)
+
+        assert "log_content" in _cols(conn, "events")
+        # Pre-existing rows survive, with NULL for the new column
+        row = conn.execute("SELECT message, log_content FROM events").fetchone()
+        assert row[0] == "old event"
+        assert row[1] is None
+        # And the compatibility view exposes the new column
+        assert "log_content" in [
+            d[0] for d in conn.execute("SELECT * FROM blq_load_events()").description
+        ]
+        conn.close()
+
+    def test_migrated_db_accepts_writes_with_log_content(self, tmp_path):
+        bird = tmp_path / ".bird"
+        bird.mkdir()
+        _build_pre_log_content_db(bird / "blq.duckdb")
+
+        with BirdStore.open(bird) as store:
+            store.ensure_session("s2", "blq-test", "blq", "cli")
+            inv = InvocationRecord(
+                id="00000000-0000-0000-0000-0000000000bb",
+                session_id="s2",
+                cmd="pytest",
+                cwd="/tmp",
+                exit_code=1,
+                client_id="blq-test",
+                source_name="test",
+            )
+            store.write_invocation(inv)
+            store.write_events(
+                inv.id,
+                [{"severity": "error", "message": "asse...", "log_content": PYTEST_FAILURE_LOG}],
+                client_id="blq-test",
+            )
+            got = store.connection.execute(
+                "SELECT log_content FROM events WHERE message = 'asse...'"
+            ).fetchone()[0]
+        assert IMPLICATED_SOURCE_LINE in got
+
+    def test_migration_converges(self, tmp_path):
+        """A repaired DB reports healthy and re-opening is a no-op."""
+        bird = tmp_path / ".bird"
+        bird.mkdir()
+        db = bird / "blq.duckdb"
+        _build_pre_log_content_db(db)
+
+        conn = duckdb.connect(str(db))
+        BirdStore._ensure_schema(conn, bird)
+        version = conn.execute(
+            "SELECT value FROM blq_metadata WHERE key='schema_version'"
+        ).fetchone()[0]
+        assert version == _bird_mod.SCHEMA_VERSION
+        assert BirdStore._needs_repair(conn, version) is False
+        BirdStore._ensure_schema(conn, bird)
+        assert "log_content" in _cols(conn, "events")
+        conn.close()
+
+    def test_column_missing_at_current_version_is_still_healed(self, tmp_path):
+        """Version-independent self-heal: a DB whose version already advanced
+        past the migration but lacks the column (a silently-failed ALTER) is
+        repaired anyway — the failure mode #52's predecessor bug hit."""
+        bird = tmp_path / ".bird"
+        bird.mkdir()
+        db = bird / "blq.duckdb"
+        conn = duckdb.connect(str(db))
+        _apply(conn, _schema_without_log_content())
+        # version left at current — nothing version-based would fire
+        conn.execute(
+            f"UPDATE blq_metadata SET value='{_bird_mod.SCHEMA_VERSION}' WHERE key='schema_version'"
+        )
+        assert BirdStore._needs_repair(conn, _bird_mod.SCHEMA_VERSION) is True
+        BirdStore._ensure_schema(conn, bird)
+        assert "log_content" in _cols(conn, "events")
+        conn.close()
+
+
+@pytest.mark.parametrize("severity", ["error"])
+def test_log_content_reaches_mcp_event_response(initialized_project, run_adhoc_command, severity):
+    """The MCP `blq_event` response carries the block (it previously exposed a
+    `raw_text` key that duck_hunt never populates)."""
+    from blq.serve import _event_impl
+
+    run_adhoc_command(_failing_pytest_script(initialized_project), format="pytest_text")
+
+    conn = get_connection(Path(".bird"))
+    ref = conn.execute(
+        f"SELECT ref FROM blq_load_events() WHERE severity = '{severity}'"
+    ).fetchone()[0]
+
+    response = _event_impl(ref)
+    assert response is not None
+    assert IMPLICATED_SOURCE_LINE in (response.get("log_content") or "")

--- a/tests/test_schema_repair.py
+++ b/tests/test_schema_repair.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import duckdb
 
 import blq.bird as _bird_mod
-from blq.bird import BirdStore
+from blq.bird import SCHEMA_VERSION, BirdStore
 
 SCHEMA = (Path(_bird_mod.__file__).parent / "bird_schema.sql").read_text()
 
@@ -57,7 +57,7 @@ def test_stuck_db_self_heals_and_preserves_data(tmp_path):
     c = duckdb.connect(str(db))
     assert "sandbox" in _cols(c, "attempts")
     assert "extension_data" not in _cols(c, "attempts")
-    assert BirdStore._needs_repair(c, "3.0.0") is True
+    assert BirdStore._needs_repair(c, "3.0.0") is True  # missing column, old version
 
     BirdStore._ensure_schema(c, bird)
 
@@ -78,7 +78,9 @@ def test_stuck_db_self_heals_and_preserves_data(tmp_path):
     )
 
     # converges: a repaired DB is a fast no-op on the next open
-    assert BirdStore._needs_repair(c, "3.0.0") is False
+    assert BirdStore._needs_repair(c, SCHEMA_VERSION) is False
+    # ...but a DB still *claiming* an older version has migrations pending
+    assert BirdStore._needs_repair(c, "3.0.0") is True
     c.close()
 
 
@@ -88,7 +90,9 @@ def test_fresh_db_is_healthy_and_no_op(tmp_path):
     c = duckdb.connect(str(bird / "blq.duckdb"))
     BirdStore._ensure_schema(c, bird)  # fresh init
     assert "extension_data" in _cols(c, "attempts")
-    assert BirdStore._needs_repair(c, "3.0.0") is False
+    # Version-agnostic: a freshly initialized DB is at SCHEMA_VERSION and healthy.
+    # (Asserting a literal here would go stale on every schema bump — it did.)
+    assert BirdStore._needs_repair(c, SCHEMA_VERSION) is False
     # re-open is a no-op and stays healthy
     BirdStore._ensure_schema(c, bird)
     assert "extension_data" in _cols(c, "attempts")


### PR DESCRIPTION
Fixes #52.

duck_hunt returns `log_content` carrying the entire failure block, and blq already receives it (`SELECT * FROM read_duck_hunt_log(...)`, `query.py:219`) — `parse_log_content()` puts it straight into the event dict. Neither storage backend had a column for it, so it was dropped at write time. Measured on the issue's one-assertion pytest failure: **271 chars available, 7 persisted** (`message` = `'asse...'`), with only `log_line_start`/`log_line_end` kept — pointers into a log that is not retained unless `--keep-raw`/`run.keep_raw`.

## What changed

**BIRD (default).** New `events.log_content` column, exposed through `blq_events_flat` → `blq_load_events()`, written by `BirdStore.write_events()` — the single choke point every BIRD caller funnels through (`execution.py:546`, `bird.py:1776`, `storage.py:487`, `record_cmd.py:386`).

**Parquet (legacy).** `PARQUET_SCHEMA`'s vestigial `("raw_text", "VARCHAR")` becomes `("log_content", "VARCHAR")`; `write_run_parquet()` populates it from the same event dict.

**MCP.** `_event_impl` returned a `"raw_text"` key read from a column nothing populated, so it was always `null`. It is now `"log_content"` and carries the block. `AGENTS.md`'s documented `event` response was updated to match.

**`blq migrate --to-bird`** now carries `log_content` across when importing old parquet (NULL for files written before this change).

## Migration for existing databases

This is the part that had to be handled rather than assumed, since `CREATE TABLE IF NOT EXISTS` will not add a column to a database that already exists.

Schema version `3.0.0` → `3.1.0`, and the existing self-heal machinery in `BirdStore._ensure_schema` does the work on the next `BirdStore.open()` — no user action, no `blq migrate` invocation needed (`blq migrate` is parquet→BIRD data import; it is not the schema-migration path).

Two layers, mirroring how `extension_data` is handled:

1. **Version-keyed migration** (`_apply_migrations`, `3.0.0 -> 3.1.0`). `_needs_repair` now compares against `SCHEMA_VERSION` instead of a hardcoded `(3, 0)`, so the DB is picked up, views are dropped (DuckDB blocks `ALTER` while views depend on the table — the exact wall that left old DBs stuck without `extension_data`), the column is added, and the schema file re-applied recreates every view.
2. **Version-independent reconcile.** `REQUIRED_COLUMNS` now drives both `_needs_repair` and `_reconcile_schema`, so a database whose *version* advanced without the `ALTER` actually landing is still repaired. That is the failure mode 1.0.2 shipped a fix for; this change generalizes the mechanism rather than adding a second one-off.

Verified end to end, not only by unit test: I rebuilt a database from **`main`'s actual shipped `bird_schema.sql`** (version 3.0.0, no `log_content`), inserted a prior invocation + event, then ran a real `blq exec -- python -m pytest`:

```
version before: 3.0.0
events has log_content before: False
version after: 3.1.0
  message='asse...'             log_content_len=271
  message='pre-existing event'  log_content_len=None
```

Pre-existing rows survive with NULL; the new row carries the full block including `+  where None = normalize(5)`, the line that names the function under test (which is what #48 asks for). The same real-pytest run was verified on a fresh BIRD project and on a fresh `--parquet` project.

## The `raw_text` decision

**Renamed, not added.** `raw_text` was dead: nothing wrote it, and its only would-be reader (`serve.py:1080`) looked up a key duck_hunt does not emit, so it was always NULL. `docs/design/duck-hunt-v3-migration.md` already records `raw_text` → `log_content` as *the intended migration* (lines 16, 110, 142) — the `ref_*` half of that plan landed previously and this was the leftover. Adding a `log_content` beside a permanently-NULL `raw_text` would have left exactly the two half-used columns the schema does not need.

Old parquet files keep their `raw_text` column and remain readable: `blq_load_events()` reads with `union_by_name = true`, so a mixed directory yields both columns with NULLs where absent. Verified directly:

```
mixed-schema read: [('asse...', has_log_content=False, has_raw_text=True),   # old file
                    ('asse...', has_log_content=True,  has_raw_text=False)]  # new file
row count: 2
```

The MCP response key changes name in the same move; since it only ever emitted `null`, no consumer can have been reading data from it.

I also removed `BIRD_SCHEMA_VERSION = "2.1.0"` from `bird.py` — a second, stale version constant that nothing read. Leaving it next to the new `SCHEMA_VERSION` would have been the same failure in miniature.

## Cap

`LOG_CONTENT_MAX_CHARS = 32_768`, applied in both write paths. The value is bounded in practice (the failure block, not the log) but not in principle, and every event of a run carries its own copy. 32K is far above any realistic traceback.

Truncation is **visible in the value**, not silent — this codebase has been bitten by quietly-shortened values:

```
... [blq: log_content truncated to 32768 of 91234 chars]
```

## Tests

Baseline on `main`: **1345 passed**. After: **1357 passed** (+12 new), 0 regressions. Run in both fixed and randomized order; `ruff check` and `ruff format --check` clean.

New `tests/test_log_content_persistence.py` covers: end-to-end persistence through `cmd_exec` for **both** fixtures (`initialized_project`, `initialized_project_parquet`), the schema shape, the cap (unit + through `write_events`), and four migration cases (column added without losing rows, writes accepted afterwards, convergence to a no-op, and the healed-at-current-version case). Each was confirmed red before implementation, and I ran a negative control (removing the `events` entry from `REQUIRED_COLUMNS`) to prove the migration tests actually depend on the new machinery rather than passing incidentally.

**Two existing tests changed — `tests/test_schema_repair.py`.** Both asserted `_needs_repair(conn, "3.0.0") is False`. The requirement they encode (*a healthy database is a fast no-op and must not drop/recreate views on every connect*) is real and is preserved — they now assert against `SCHEMA_VERSION`. What they additionally encoded was an assumption, now invalidated: that 3.0.0 *is* the current version. A database claiming 3.0.0 genuinely does need repair now, since it predates this migration, so `True` is the correct answer to the question they were asking; the literal was the stale part. I added an explicit assertion of that new behavior rather than dropping the coverage.

## Deliberately left out

- **`blq context` fallback.** It still exits with *"Raw log not found — Hint: use --keep-raw"* when raw retention is off, even though the block it wants is now in the database. Making it fall back to `log_content` is the natural follow-up and is what turns this data into user-visible recovery, but it changes command output and deserves its own change and tests.
- **`log_file`**, the other field `docs/design/duck-hunt-v3-migration.md` lists as unpersisted. Out of scope for #52.
- **Configurable cap.** `truncate_log_content()` takes a `max_chars` argument, but nothing plumbs it to `config.toml`. A constant seemed right until there is evidence 32K is wrong.
- **The `events.context` column** is still written from `event.get("context")`, which duck_hunt only populates when called with `context := N` — which blq never does. It is a second always-NULL column, but unlike `raw_text` it is a real duck_hunt field with a defined meaning, so I left it rather than widening this change.

## Not resolved

`mypy src/blq/` (a CI step) does not run in my local venv: Python 3.14 + `python_version = "3.10"` in `pyproject.toml` makes mypy reject numpy's bundled stubs (`Type statement is only supported in Python 3.12 and greater`) before it checks any blq source. Pre-existing and environmental, unrelated to this diff, but it means the mypy gate is unverified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JAindVccsTsdMTx3SV1iU
